### PR TITLE
[okera] Set default hostname verifier to allow mismatch

### DIFF
--- a/presto-password-authenticators/src/main/java/com/facebook/presto/password/OkeraAuthenticator.java
+++ b/presto-password-authenticators/src/main/java/com/facebook/presto/password/OkeraAuthenticator.java
@@ -273,6 +273,7 @@ public class OkeraAuthenticator
         SSLContext sc = SSLContext.getInstance("SSL");
         sc.init(null, trustAllCerts, new java.security.SecureRandom());
         HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+        HttpsURLConnection.setDefaultHostnameVerifier(hv);
 
         restServerSslConfigured = true;
     }


### PR DESCRIPTION
The verifier was created but not added as default to the
HTTPSURLConnection. Change just does that, and helps presto
talk to rest-server if hostname mismatch in the SSL cert.